### PR TITLE
Adjust PkgCreator arguments

### DIFF
--- a/Daylite/Daylite.pkg.recipe
+++ b/Daylite/Daylite.pkg.recipe
@@ -88,9 +88,9 @@
 					<string>%pkgroot%</string>
 					<key>scripts</key>
 					<string>Scripts</string>
+					<key>pkgname</key>
+					<string>%NAME%-%version%</string>
 				</dict>
-				<key>pkgname</key>
-				<string>%NAME%-%version%</string>
 			</dict>
 			<key>Processor</key>
 			<string>PkgCreator</string>


### PR DESCRIPTION
`pkgname` is [intended](https://github.com/autopkg/autopkg/blob/e36d5cba2823dbdfcb69a41a38b1aef9fb76121c/Code/autopkgserver/autopkgserver#L47) to be in the `pkg_request` dictionary, not as a standalone argument for [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator).