### PR TITLE
Update RingCentral.munki.recipe

### DIFF
--- a/RingCentral/RingCentral.munki.recipe
+++ b/RingCentral/RingCentral.munki.recipe
@@ -16,6 +16,10 @@
         <string>RingCentral</string>
         <key>pkginfo</key>
         <dict>
+            <key>blocking_applications</key>
+            <array>
+                <string>RingCentral.app</string>
+            </array>
             <key>catalogs</key>
             <array>
                 <string>testing</string>
@@ -25,7 +29,7 @@
             <key>display_name</key>
             <string>RingCentral</string>
             <key>minimum_os_version</key>
-            <string>10.13</string>
+            <string>10.10.0</string>
             <key>name</key>
             <string>%NAME%</string>
             <key>unattended_install</key>


### PR DESCRIPTION
Despite what their site (https://support.ringcentral.com/article/Supported-Browsers-RingCentral-App-Web.html) says requiring 10.13, `LSMinimumSystemVersion` is 10.10.0, and I've confirmed it works on 10.12.6.

Also, I was able to uninstall the app while it was running. Although RingCentral.app was removed from /Applications, it was still running in memory.