### PR TITLE
Update RingCentral.munki.recipe

### DIFF
--- a/RingCentral/RingCentral.munki.recipe
+++ b/RingCentral/RingCentral.munki.recipe
@@ -18,7 +18,7 @@
         <dict>
             <key>blocking_applications</key>
             <array>
-                <string>RingCentral.app</string>
+                <string>RingCentral</string>
             </array>
             <key>catalogs</key>
             <array>
@@ -43,6 +43,74 @@
     <key>Process</key>
     <array>
         <dict>
+            <key>Processor</key>
+            <string>FlatPkgUnpacker</string>
+            <key>Arguments</key>
+            <dict>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/unpack</string>
+                <key>flat_pkg_path</key>
+                <string>%pathname%</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>PkgPayloadUnpacker</string>
+            <key>Arguments</key>
+            <dict>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/Applications/</string>
+                <key>pkg_payload_path</key>
+                <string>%RECIPE_CACHE_DIR%/unpack/com.ringcentral.glip.pkg/Payload</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiInstallsItemsCreator</string>
+            <key>Arguments</key>
+            <dict>
+                <key>faux_root</key>
+                <string>%RECIPE_CACHE_DIR%</string>
+                <key>installs_item_paths</key>
+                <array>
+                    <string>/Applications/RingCentral.app</string>
+                </array>
+            </dict>
+        </dict>
+       <dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+          <key>Processor</key>
+          <string>Versioner</string>
+          <key>Arguments</key>
+          <dict>
+              <key>input_plist_path</key>
+              <string>%destination_path%/RingCentral.app/Contents/Info.plist</string>
+              <key>plist_version_key</key>
+              <string>CFBundleShortVersionString</string>
+          </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+            <key>Arguments</key>
+            <dict>
+                <key>additional_pkginfo</key>
+                <dict>
+                    <key>version</key>
+                    <string>%version%</string>
+                </dict>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
             <key>Arguments</key>
             <dict>
                 <key>pkg_path</key>
@@ -50,8 +118,18 @@
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
             </dict>
+        </dict>
+        <dict>
             <key>Processor</key>
-            <string>MunkiImporter</string>
+            <string>PathDeleter</string>
+            <key>Arguments</key>
+            <dict>
+                <key>path_list</key>
+                <array>
+                    <string>%RECIPE_CACHE_DIR%/Applications</string>
+                    <string>%RECIPE_CACHE_DIR%/unpack</string>
+                </array>
+            </dict>
         </dict>
     </array>
 </dict>


### PR DESCRIPTION
Updated to create an installs array for the .app on disk and use the apps version.

Amended blocking applications

```Processing /Users/ben/Git/other-recipes/bradclare-recipes/RingCentral/RingCentral.munki.recipe...
WARNING: /Users/ben/Git/other-recipes/bradclare-recipes/RingCentral/RingCentral.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'RingCentral.pkg',
           'url': 'https://app.ringcentral.com/download/RingCentral.pkg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/ben/Library/AutoPkg/Cache/com.github.bradclare.munki.ringcentral/downloads/RingCentral.pkg
{'Output': {'pathname': '/Users/ben/Library/AutoPkg/Cache/com.github.bradclare.munki.ringcentral/downloads/RingCentral.pkg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: RingCentral, '
                                        'Inc. (M932RC5J66)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '/Users/ben/Library/AutoPkg/Cache/com.github.bradclare.munki.ringcentral/downloads/RingCentral.pkg'}}
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "RingCentral.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2021-04-08 20:44:51 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: RingCentral, Inc. (M932RC5J66)
CodeSignatureVerifier:        Expires: 2023-08-17 12:22:11 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            95 A7 2F C4 4F 3C BF 2C CB 8E 71 5D 94 0F EF 24 6A 00 EB 52 5A 99 
CodeSignatureVerifier:            45 4A 26 9F D7 EA A9 30 1C 43
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
FlatPkgUnpacker
{'Input': {'destination_path': '/Users/ben/Library/AutoPkg/Cache/com.github.bradclare.munki.ringcentral/unpack',
           'flat_pkg_path': '/Users/ben/Library/AutoPkg/Cache/com.github.bradclare.munki.ringcentral/downloads/RingCentral.pkg',
           'purge_destination': True}}
FlatPkgUnpacker: Unpacked /Users/ben/Library/AutoPkg/Cache/com.github.bradclare.munki.ringcentral/downloads/RingCentral.pkg to /Users/ben/Library/AutoPkg/Cache/com.github.bradclare.munki.ringcentral/unpack
{'Output': {}}
PkgPayloadUnpacker
{'Input': {'destination_path': '/Users/ben/Library/AutoPkg/Cache/com.github.bradclare.munki.ringcentral/Applications/',
           'pkg_payload_path': '/Users/ben/Library/AutoPkg/Cache/com.github.bradclare.munki.ringcentral/unpack/com.ringcentral.glip.pkg/Payload',
           'purge_destination': True}}
PkgPayloadUnpacker: Unpacked /Users/ben/Library/AutoPkg/Cache/com.github.bradclare.munki.ringcentral/unpack/com.ringcentral.glip.pkg/Payload to /Users/ben/Library/AutoPkg/Cache/com.github.bradclare.munki.ringcentral/Applications/
{'Output': {}}
MunkiInstallsItemsCreator
{'Input': {'faux_root': '/Users/ben/Library/AutoPkg/Cache/com.github.bradclare.munki.ringcentral',
           'installs_item_paths': ['/Applications/RingCentral.app']}}
MunkiInstallsItemsCreator: Created installs item for /Applications/RingCentral.app
{'Output': {'additional_pkginfo': {'installs': [{'CFBundleIdentifier': 'com.ringcentral.glip',
                                                 'CFBundleName': 'RingCentral',
                                                 'CFBundleShortVersionString': '21.2.10.949',
                                                 'CFBundleVersion': '21.2.10.949',
                                                 'minosversion': '10.10.0',
                                                 'path': '/Applications/RingCentral.app',
                                                 'type': 'application',
                                                 'version_comparison_key': 'CFBundleShortVersionString'}]}}}
MunkiPkginfoMerger
{'Input': {'additional_pkginfo': {'installs': [{'CFBundleIdentifier': 'com.ringcentral.glip',
                                                'CFBundleName': 'RingCentral',
                                                'CFBundleShortVersionString': '21.2.10.949',
                                                'CFBundleVersion': '21.2.10.949',
                                                'minosversion': '10.10.0',
                                                'path': '/Applications/RingCentral.app',
                                                'type': 'application',
                                                'version_comparison_key': 'CFBundleShortVersionString'}]},
           'pkginfo': {'blocking_applications': ['RingCentral.app'],
                       'catalogs': ['testing'],
                       'description': 'Everything you need in one beautiful '
                                      'app; Team messaging, video meetings, '
                                      'and a business phone-reimagined so you '
                                      'can do more from anywhere.',
                       'display_name': 'RingCentral',
                       'minimum_os_version': '10.10.0',
                       'name': 'RingCentral',
                       'unattended_install': True}}}
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleIdentifier': 'com.ringcentral.glip', 'CFBundleName': 'RingCentral', 'CFBundleShortVersionString': '21.2.10.949', 'CFBundleVersion': '21.2.10.949', 'minosversion': '10.10.0', 'path': '/Applications/RingCentral.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}]} into pkginfo
{'Output': {'pkginfo': {'blocking_applications': ['RingCentral.app'],
                        'catalogs': ['testing'],
                        'description': 'Everything you need in one beautiful '
                                       'app; Team messaging, video meetings, '
                                       'and a business phone-reimagined so you '
                                       'can do more from anywhere.',
                        'display_name': 'RingCentral',
                        'installs': [{'CFBundleIdentifier': 'com.ringcentral.glip',
                                      'CFBundleName': 'RingCentral',
                                      'CFBundleShortVersionString': '21.2.10.949',
                                      'CFBundleVersion': '21.2.10.949',
                                      'minosversion': '10.10.0',
                                      'path': '/Applications/RingCentral.app',
                                      'type': 'application',
                                      'version_comparison_key': 'CFBundleShortVersionString'}],
                        'minimum_os_version': '10.10.0',
                        'name': 'RingCentral',
                        'unattended_install': True}}}
Versioner
{'Input': {'input_plist_path': '/Users/ben/Library/AutoPkg/Cache/com.github.bradclare.munki.ringcentral/Applications//RingCentral.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Found version 21.2.10.949 in file /Users/ben/Library/AutoPkg/Cache/com.github.bradclare.munki.ringcentral/Applications//RingCentral.app/Contents/Info.plist
{'Output': {'version': '21.2.10.949'}}
MunkiPkginfoMerger
{'Input': {'additional_pkginfo': {'version': '21.2.10.949'},
           'pkginfo': {'blocking_applications': ['RingCentral.app'],
                       'catalogs': ['testing'],
                       'description': 'Everything you need in one beautiful '
                                      'app; Team messaging, video meetings, '
                                      'and a business phone-reimagined so you '
                                      'can do more from anywhere.',
                       'display_name': 'RingCentral',
                       'installs': [{'CFBundleIdentifier': 'com.ringcentral.glip',
                                     'CFBundleName': 'RingCentral',
                                     'CFBundleShortVersionString': '21.2.10.949',
                                     'CFBundleVersion': '21.2.10.949',
                                     'minosversion': '10.10.0',
                                     'path': '/Applications/RingCentral.app',
                                     'type': 'application',
                                     'version_comparison_key': 'CFBundleShortVersionString'}],
                       'minimum_os_version': '10.10.0',
                       'name': 'RingCentral',
                       'unattended_install': True}}}
MunkiPkginfoMerger: Merged {'version': '21.2.10.949'} into pkginfo
{'Output': {'pkginfo': {'blocking_applications': ['RingCentral.app'],
                        'catalogs': ['testing'],
                        'description': 'Everything you need in one beautiful '
                                       'app; Team messaging, video meetings, '
                                       'and a business phone-reimagined so you '
                                       'can do more from anywhere.',
                        'display_name': 'RingCentral',
                        'installs': [{'CFBundleIdentifier': 'com.ringcentral.glip',
                                      'CFBundleName': 'RingCentral',
                                      'CFBundleShortVersionString': '21.2.10.949',
                                      'CFBundleVersion': '21.2.10.949',
                                      'minosversion': '10.10.0',
                                      'path': '/Applications/RingCentral.app',
                                      'type': 'application',
                                      'version_comparison_key': 'CFBundleShortVersionString'}],
                        'minimum_os_version': '10.10.0',
                        'name': 'RingCentral',
                        'unattended_install': True,
                        'version': '21.2.10.949'}}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '/Users/ben/Library/AutoPkg/Cache/com.github.bradclare.munki.ringcentral/downloads/RingCentral.pkg',
           'pkginfo': {'blocking_applications': ['RingCentral.app'],
                       'catalogs': ['testing'],
                       'description': 'Everything you need in one beautiful '
                                      'app; Team messaging, video meetings, '
                                      'and a business phone-reimagined so you '
                                      'can do more from anywhere.',
                       'display_name': 'RingCentral',
                       'installs': [{'CFBundleIdentifier': 'com.ringcentral.glip',
                                     'CFBundleName': 'RingCentral',
                                     'CFBundleShortVersionString': '21.2.10.949',
                                     'CFBundleVersion': '21.2.10.949',
                                     'minosversion': '10.10.0',
                                     'path': '/Applications/RingCentral.app',
                                     'type': 'application',
                                     'version_comparison_key': 'CFBundleShortVersionString'}],
                       'minimum_os_version': '10.10.0',
                       'name': 'RingCentral',
                       'unattended_install': True,
                       'version': '21.2.10.949'},
           'repo_subdirectory': 'apps/RingCentral'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/RingCentral/RingCentral-21.2.10.949.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/RingCentral/RingCentral-21.2.10.949.pkg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'RingCentral',
                                                       'pkg_repo_path': 'apps/RingCentral/RingCentral-21.2.10.949.pkg',
                                                       'pkginfo_path': 'apps/RingCentral/RingCentral-21.2.10.949.plist',
                                                       'version': '21.2.10.949'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'ben',
                                         'creation_date': datetime.datetime(2021, 5, 2, 11, 34, 50),
                                         'munki_version': '5.3.0.4335',
                                         'os_version': '10.15.7'},
                           'autoremove': False,
                           'blocking_applications': ['RingCentral.app'],
                           'catalogs': ['testing'],
                           'description': 'Everything you need in one '
                                          'beautiful app; Team messaging, '
                                          'video meetings, and a business '
                                          'phone-reimagined so you can do more '
                                          'from anywhere.',
                           'display_name': 'RingCentral',
                           'installed_size': 566912,
                           'installer_item_hash': '41b642a2dde3702627f0c82c5e389068fe8877568cd35a82e5b5af3d48e44047',
                           'installer_item_location': 'apps/RingCentral/RingCentral-21.2.10.949.pkg',
                           'installer_item_size': 210367,
                           'installs': [{'CFBundleIdentifier': 'com.ringcentral.glip',
                                         'CFBundleName': 'RingCentral',
                                         'CFBundleShortVersionString': '21.2.10.949',
                                         'CFBundleVersion': '21.2.10.949',
                                         'minosversion': '10.10.0',
                                         'path': '/Applications/RingCentral.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'minimum_os_version': '10.10.0',
                           'name': 'RingCentral',
                           'receipts': [{'installed_size': 566912,
                                         'packageid': 'com.ringcentral.glip',
                                         'version': '21.2.10'}],
                           'unattended_install': True,
                           'uninstall_method': 'removepackages',
                           'uninstallable': True,
                           'version': '21.2.10.949'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/RingCentral/RingCentral-21.2.10.949.pkg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/apps/RingCentral/RingCentral-21.2.10.949.plist'}}
PathDeleter
{'Input': {'path_list': ['/Users/ben/Library/AutoPkg/Cache/com.github.bradclare.munki.ringcentral/Applications',
                         '/Users/ben/Library/AutoPkg/Cache/com.github.bradclare.munki.ringcentral/unpack']}}
PathDeleter: Deleted /Users/ben/Library/AutoPkg/Cache/com.github.bradclare.munki.ringcentral/Applications
PathDeleter: Deleted /Users/ben/Library/AutoPkg/Cache/com.github.bradclare.munki.ringcentral/unpack
{'Output': {}}
Receipt written to /Users/ben/Library/AutoPkg/Cache/com.github.bradclare.munki.ringcentral/receipts/RingCentral.munki-receipt-20210502-123451.plist

The following new items were imported into Munki:
    Name         Version      Catalogs  Pkginfo Path                                    Pkg Repo Path                                 Icon Repo Path  
    ----         -------      --------  ------------                                    -------------                                 --------------  
    RingCentral  21.2.10.949  testing   apps/RingCentral/RingCentral-21.2.10.949.plist  apps/RingCentral/RingCentral-21.2.10.949.pkg                  
```