### PR TITLE
Remove extra "s" from PathDeleter processor

### DIFF
--- a/Daylite/Daylite.munki.recipe
+++ b/Daylite/Daylite.munki.recipe
@@ -78,7 +78,7 @@ fi
 		</dict>
 		<dict>
 			<key>Processor</key>
-			<string>PathDeleter</string>s
+			<string>PathDeleter</string>
 			<key>Arguments</key>
 			<dict>
 				<key>path_list</key>

--- a/Daylite/Daylite.pkg.recipe
+++ b/Daylite/Daylite.pkg.recipe
@@ -97,7 +97,7 @@
 		</dict>
 		<dict>
 			<key>Processor</key>
-			<string>PathDeleter</string>s
+			<string>PathDeleter</string>
 			<key>Arguments</key>
 			<dict>
 				<key>path_list</key>


### PR DESCRIPTION
This extra character is causing plist linting to fail:

```
% find * -iname "*.recipe" -exec plutil -lint "{}" '+' | grep -v OK
Daylite/Daylite.pkg.recipe: Encountered unexpected character s on line 100 while looking for open tag
Daylite/Daylite.munki.recipe: Encountered unexpected character s on line 81 while looking for open tag
```