### PR TITLE
Update RingCentral.munki.recipe

### DIFF
--- a/RingCentral/RingCentral.munki.recipe
+++ b/RingCentral/RingCentral.munki.recipe
@@ -3,13 +3,17 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Munki recipe for RingCentral</string>
+    <string>Munki recipe for RingCentral
+
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
     <key>Comment</key>
     <string>https://support.ringcentral.com/article/Using-Latest-RingCentral-App.html</string>
     <key>Identifier</key>
     <string>com.github.bradclare.munki.ringcentral</string>
     <key>Input</key>
     <dict>
+        <key>DERIVE_MIN_OS</key>
+        <string>YES</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/RingCentral</string>
         <key>NAME</key>
@@ -28,8 +32,6 @@
             <string>Everything you need in one beautiful app; Team messaging, video meetings, and a business phone-reimagined so you can do more from anywhere.</string>
             <key>display_name</key>
             <string>RingCentral</string>
-            <key>minimum_os_version</key>
-            <string>10.10.0</string>
             <key>name</key>
             <string>%NAME%</string>
             <key>unattended_install</key>
@@ -37,7 +39,7 @@
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>2.7</string>
     <key>ParentRecipe</key>
     <string>com.github.bradclare.download.ringcentral</string>
     <key>Process</key>
@@ -79,6 +81,8 @@
                 <array>
                     <string>/Applications/RingCentral.app</string>
                 </array>
+                <key>derive_minimum_os_version</key>
+                <string>%DERIVE_MIN_OS%</string>
             </dict>
         </dict>
        <dict>


### PR DESCRIPTION
Hi, @bradclare 

The RingCentral Munki recipe currently doesn't set the `minimum_os_version` from the App's info.plist, and as such a default value of 10.5.0 would be be set were it not for `minimum_os_version` being hard coded to 10.10.0

This PR adds in support for the new `derive_minimum_os_version` key in the `MunkiInstallsItemsCreator` processor. With this set the min_os_version becomes 10.11.0

This change requires AutoPkg version 2.7 or a higher, if compatibility with older versions of AutoPkg is needed, the same result could be achieved with something like below.

```
        <dict>
            <key>Arguments</key>
            <dict>
                <key>info_path</key>
                <string>%RECIPE_CACHE_DIR%/Applications/APP_NAME.app</string>
                <key>plist_keys</key>
                <dict>
                    <key>LSMinimumSystemVersion</key>
                    <string>min_os_ver</string>
                </dict>
            </dict>
            <key>Processor</key>
            <string>PlistReader</string>
        </dict>
        <dict>
             <key>Arguments</key>
             <dict>
                <key>additional_pkginfo</key>
                <dict>
                    <key>minimum_os_version</key>
                    <string>%min_os_ver%</string>
                </dict>
            </dict>
            <key>Processor</key>
            <string>MunkiPkginfoMerger</string>
        </dict>
```

Output from a successful verbose run:

```
autopkg run -v /Users/paul/Documents/GitHub/AutoPkg\ Repos/bradclare-recipes/RingCentral/RingCentral.munki.recipe 
Processing /Users/paul/Documents/GitHub/AutoPkg Repos/bradclare-recipes/RingCentral/RingCentral.munki.recipe...
WARNING: /Users/paul/Documents/GitHub/AutoPkg Repos/bradclare-recipes/RingCentral/RingCentral.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
URLDownloader: Storing new Last-Modified header: Tue, 06 Dec 2022 05:11:07 GMT
URLDownloader: Storing new ETag header: "37372a4947e6405944986a86a559adc7-39"
URLDownloader: Downloaded /Users/paul/Library/AutoPkg/Cache/com.github.bradclare.munki.ringcentral/downloads/RingCentral.pkg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "RingCentral.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2022-11-22 08:12:31 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: RingCentral, Inc. (M932RC5J66)
CodeSignatureVerifier:        Expires: 2023-08-17 12:22:11 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            95 A7 2F C4 4F 3C BF 2C CB 8E 71 5D 94 0F EF 24 6A 00 EB 52 5A 99 
CodeSignatureVerifier:            45 4A 26 9F D7 EA A9 30 1C 43
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
FlatPkgUnpacker
FlatPkgUnpacker: Unpacked /Users/paul/Library/AutoPkg/Cache/com.github.bradclare.munki.ringcentral/downloads/RingCentral.pkg to /Users/paul/Library/AutoPkg/Cache/com.github.bradclare.munki.ringcentral/unpack
PkgPayloadUnpacker
PkgPayloadUnpacker: Unpacked /Users/paul/Library/AutoPkg/Cache/com.github.bradclare.munki.ringcentral/unpack/com.ringcentral.glip.pkg/Payload to /Users/paul/Library/AutoPkg/Cache/com.github.bradclare.munki.ringcentral/Applications/
MunkiInstallsItemsCreator
MunkiInstallsItemsCreator: Created installs item for /Applications/RingCentral.app
MunkiInstallsItemsCreator: Derived minimum os version as: 10.11.0
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleIdentifier': 'com.ringcentral.glip', 'CFBundleName': 'RingCentral', 'CFBundleShortVersionString': '22.4.21.5727', 'CFBundleVersion': '22.4.21.5727', 'minosversion': '10.11.0', 'path': '/Applications/RingCentral.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}], 'minimum_os_version': '10.11.0'} into pkginfo
Versioner
Versioner: Found version 22.4.21.5727 in file /Users/paul/Library/AutoPkg/Cache/com.github.bradclare.munki.ringcentral/Applications//RingCentral.app/Contents/Info.plist
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'version': '22.4.21.5727'} into pkginfo
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/RingCentral/RingCentral-22.4.21.5727.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/RingCentral/RingCentral-22.4.21.5727.pkg
PathDeleter
PathDeleter: Deleted /Users/paul/Library/AutoPkg/Cache/com.github.bradclare.munki.ringcentral/Applications
PathDeleter: Deleted /Users/paul/Library/AutoPkg/Cache/com.github.bradclare.munki.ringcentral/unpack
Receipt written to /Users/paul/Library/AutoPkg/Cache/com.github.bradclare.munki.ringcentral/receipts/RingCentral.munki-receipt-20221220-163719.plist

The following new items were downloaded:
    Download Path                                                                                       
    -------------                                                                                       
    /Users/paul/Library/AutoPkg/Cache/com.github.bradclare.munki.ringcentral/downloads/RingCentral.pkg  

The following new items were imported into Munki:
    Name         Version       Catalogs  Pkginfo Path                                     Pkg Repo Path                                  Icon Repo Path  
    ----         -------       --------  ------------                                     -------------                                  --------------  
    RingCentral  22.4.21.5727  testing   apps/RingCentral/RingCentral-22.4.21.5727.plist  apps/RingCentral/RingCentral-22.4.21.5727.pkg 
```