### PR TITLE
Clarify arch override in RingCentral recipe descriptions

### DIFF
--- a/RingCentral/RingCentral.download.recipe
+++ b/RingCentral/RingCentral.download.recipe
@@ -3,7 +3,11 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Download recipe for RingCentral</string>
+    <string>Download recipe for RingCentral.
+    
+The Intel version is downloaded by default. To download the Apple Silicon version, use this DOWNLOAD_URL:
+https://app.ringcentral.com/download/RingCentral-arm64.pkg
+</string>
     <key>Comment</key>
     <string>https://support.ringcentral.com/article/Using-Latest-RingCentral-App.html</string>
     <key>Identifier</key>

--- a/RingCentral/RingCentral.munki.recipe
+++ b/RingCentral/RingCentral.munki.recipe
@@ -5,7 +5,9 @@
     <key>Description</key>
     <string>Munki recipe for RingCentral
 
-Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.
+
+If you provide a custom DOWNLOAD_URL value (e.g. to download the Apple Silicon version), be sure to also provide a supported_architectures array.</string>
     <key>Comment</key>
     <string>https://support.ringcentral.com/article/Using-Latest-RingCentral-App.html</string>
     <key>Identifier</key>


### PR DESCRIPTION
Add text to description of RingCentral.download and RingCentral.munki to clarify that the same recipes can be overridden with architecture-specific values.