### PR TITLE
Deprecate FileMaker recipes

### DIFF
--- a/FileMaker/FileMakerPro13.download.recipe
+++ b/FileMaker/FileMakerPro13.download.recipe
@@ -14,9 +14,18 @@
         <string>https://fmdl.filemaker.com/TBUB/13/fmp_trial_fm_13.0.9.904.dmg</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>FileMaker 13 is no longer supported (details: https://support.claris.com/s/article/FileMaker-announces-the-end-of-support-for-FileMaker-13-Platform-1503693097684). This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>URLDownloader</string>

--- a/FileMaker/FileMakerPro14.download.recipe
+++ b/FileMaker/FileMakerPro14.download.recipe
@@ -14,9 +14,18 @@
         <string>http://fmdl.filemaker.com/maint/emea_fba_ftn/fmp_14.0.4.406.dmg</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>FileMaker 14 is no longer supported (details: https://support.claris.com/s/article/FileMaker-announces-the-end-of-support-for-FileMaker-14-Platform). This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>URLDownloader</string>
@@ -35,4 +44,3 @@
     </array>
 </dict>
 </plist>
-

--- a/FileMaker/FileMakerPro14Trial.download.recipe
+++ b/FileMaker/FileMakerPro14Trial.download.recipe
@@ -14,9 +14,18 @@
         <string>http://fmdl.filemaker.com/TBUB/14/fmp_trial_fm_14.0.4.406.dmg</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>FileMaker 14 is no longer supported (details: https://support.claris.com/s/article/FileMaker-announces-the-end-of-support-for-FileMaker-14-Platform). This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>URLDownloader</string>

--- a/FileMaker/FileMakerServer13.download.recipe
+++ b/FileMaker/FileMakerServer13.download.recipe
@@ -14,9 +14,18 @@
         <string>http://fmdl.filemaker.com/TBUB/13/fms_trial_13.0.9.905.dmg</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>FileMaker Server 13 is no longer supported (details: https://support.claris.com/s/article/FileMaker-announces-the-end-of-support-for-FileMaker-13-Platform-1503693097684). This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>URLDownloader</string>

--- a/FileMaker/FileMakerServer14.download.recipe
+++ b/FileMaker/FileMakerServer14.download.recipe
@@ -14,9 +14,18 @@
         <string>http://fmdl.filemaker.com/maint/emea_fba_ftn/fms_14.0.4.412.dmg</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>FileMaker Server 14 is no longer supported (details: https://support.claris.com/s/article/FileMaker-announces-the-end-of-support-for-FileMaker-14-Platform). This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>URLDownloader</string>

--- a/FileMaker/FileMakerServer14Trial.download.recipe
+++ b/FileMaker/FileMakerServer14Trial.download.recipe
@@ -14,9 +14,18 @@
         <string>http://fmdl.filemaker.com/TBUB/14/fms_trial_14.0.4.412.dmg</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>FileMaker Server 14 is no longer supported (details: https://support.claris.com/s/article/Claris-support-policy). This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>URLDownloader</string>


### PR DESCRIPTION
This PR deprecates end-of-life FileMaker download recipes. Details to Claris support announcements are provided in the deprecation warning message.
