### PR TITLE
Deprecate Daylite Server recipes

### DIFF
--- a/Daylite/DayliteServer.download.recipe
+++ b/Daylite/DayliteServer.download.recipe
@@ -19,6 +19,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Daylite Server is no longer available (details: https://www.marketcircle.com/blog/announcing-our-goodbye-to-self-serve/). This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
This PR deprecates Daylite Server, which is no longer available: https://www.marketcircle.com/blog/announcing-our-goodbye-to-self-serve/
