### PR TITLE
Remove version-specific download URL for SpeechControl

### DIFF
--- a/SpeechControl/SpeechControl.download.recipe
+++ b/SpeechControl/SpeechControl.download.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.bradclare.download.SpeechControl</string>
 	<key>Input</key>
 	<dict>
-		<key>DOWNLOAD_URL</key>
-		<string>https://cdn.speech.com/fileadmin/Support/software/speechcontrol/speechcontrol4mac_swm_3.5.11.dmg</string>
 		<key>NAME</key>
 		<string>SpeechControl</string>
 	</dict>
@@ -22,10 +20,23 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>filename</key>
-				<string>%NAME%.dmg</string>
+				<key>re_pattern</key>
+				<string>&lt;p&gt;([\d\.]+) - macOS&lt;/p&gt;</string>
+				<key>result_output_var_name</key>
+				<string>version</string>
 				<key>url</key>
-				<string>%DOWNLOAD_URL%</string>
+				<string>https://www.dictation.philips.com/us/products/workflow-software/speechcontrol-device-and-application-control-software-lfh4000/#productsupport</string>
+			</dict>
+			<key>Processor</key>
+			<string>URLTextSearcher</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>filename</key>
+				<string>%NAME%-%version%.dmg</string>
+				<key>url</key>
+				<string>https://cdn.speech.com/fileadmin/Support/software/speechcontrol/speechcontrol4mac_swm_%version%.dmg</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
@@ -33,6 +44,17 @@
 		<dict>
 			<key>Processor</key>
 			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%pathname%/SpeechControl.app</string>
+				<key>requirement</key>
+				<string>anchor apple generic and identifier "com.Philips.SpeechControl" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = DUQ8LK9P92)</string>
+			</dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
The current SpeechControl recipes have a hard-coded download URL, which is contrary to the purpose of AutoPkg. This PR adds URLTextSearcher, which allows us to dynamically get a download URL for each new version of SpeechControl.

Verbose recipe run output:

```
% autopkg run -vvq 'SpeechControl/SpeechControl.download.recipe'
Processing SpeechControl/SpeechControl.download.recipe...
WARNING: SpeechControl/SpeechControl.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '<p>([\\d\\.]+) - macOS</p>',
           'result_output_var_name': 'version',
           'url': 'https://www.dictation.philips.com/us/products/workflow-software/speechcontrol-device-and-application-control-software-lfh4000/#productsupport'}}
URLTextSearcher: Found matching text (version): 3.5.11
{'Output': {'version': '3.5.11'}}
URLDownloader
{'Input': {'filename': 'SpeechControl-3.5.11.dmg',
           'url': 'https://cdn.speech.com/fileadmin/Support/software/speechcontrol/speechcontrol4mac_swm_3.5.11.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Sun, 28 Jan 2024 10:14:18 GMT
URLDownloader: Storing new ETag header: "0c1446da681976854464c0c855e496d7"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.bradclare.download.SpeechControl/downloads/SpeechControl-3.5.11.dmg
{'Output': {'download_changed': True,
            'etag': '"0c1446da681976854464c0c855e496d7"',
            'last_modified': 'Sun, 28 Jan 2024 10:14:18 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.bradclare.download.SpeechControl/downloads/SpeechControl-3.5.11.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.bradclare.download.SpeechControl/downloads/SpeechControl-3.5.11.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.bradclare.download.SpeechControl/downloads/SpeechControl-3.5.11.dmg/SpeechControl.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.Philips.SpeechControl" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = DUQ8LK9P92)'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.bradclare.download.SpeechControl/downloads/SpeechControl-3.5.11.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.s68aNt/SpeechControl.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.s68aNt/SpeechControl.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.s68aNt/SpeechControl.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.bradclare.download.SpeechControl/receipts/SpeechControl.download-receipt-20241228-115225.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.bradclare.download.SpeechControl/downloads/SpeechControl-3.5.11.dmg
```
